### PR TITLE
Always update location in iOS

### DIFF
--- a/ios/RCTBackgroundGeolocation/LocationManager.m
+++ b/ios/RCTBackgroundGeolocation/LocationManager.m
@@ -533,6 +533,10 @@ enum {
         if ([bgloc isBetterLocation:lastLocation]) {
             DDLogInfo(@"Better location found: %@", bgloc);
             lastLocation = bgloc;
+            bgloc.type = @"raw";
+            if (self.delegate && [self.delegate respondsToSelector:@selector(onLocationChanged:)]) {
+                [self.delegate onLocationChanged:[bgloc toDictionary]];
+            }
         }
     }
 


### PR DESCRIPTION
Always deliver the location updates to the client (iOS)

Edit: This is the fix for #14. The updates will come with the `type` field set to `raw` to be able to filter them on the app side.