### PR TITLE
Fix used android versions

### DIFF
--- a/android/lib/build.gradle
+++ b/android/lib/build.gradle
@@ -14,7 +14,7 @@ android {
 
 dependencies {
     compile 'com.facebook.react:react-native:+'
-    compile 'com.android.support:support-v4:+'
+    compile 'com.android.support:support-v4:25.3.0'
     compile 'com.google.android.gms:play-services-location:+'
     compile 'com.github.tony19:logback-android-core:1.1.1-6'
     compile 'com.github.tony19:logback-android-classic:1.1.1-6'

--- a/android/lib/build.gradle
+++ b/android/lib/build.gradle
@@ -15,7 +15,7 @@ android {
 dependencies {
     compile 'com.facebook.react:react-native:+'
     compile 'com.android.support:support-v4:25.3.0'
-    compile 'com.google.android.gms:play-services-location:+'
+    compile 'com.google.android.gms:play-services-location:10.2.4'
     compile 'com.github.tony19:logback-android-core:1.1.1-6'
     compile 'com.github.tony19:logback-android-classic:1.1.1-6'
     compile 'org.slf4j:slf4j-api:1.7.21'

--- a/android/lib/src/main/java/com/marianhello/react/BackgroundGeolocationModule.java
+++ b/android/lib/src/main/java/com/marianhello/react/BackgroundGeolocationModule.java
@@ -277,7 +277,10 @@ public class BackgroundGeolocationModule extends ReactContextBaseJavaModule impl
             startAndBindBackgroundService();
             success.invoke(true);
         } else {
-            //TODO: requestPermissions
+            Activity activity = getCurrentActivity();
+            if(activity == null) return;
+            String[] permissions = { Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION };
+            ActivityCompat.requestPermissions(activity, permissions, PERMISSION_REQUEST_CODE);
         }
     }
 


### PR DESCRIPTION
To have the client project stable, the it should not always get the latest version of say the android support library. Like now the latest can be an Alpha build and that can conflict with the client apps versions.