### PR TITLE
Use gradle to choose authority

### DIFF
--- a/android/lib/src/main/AndroidManifest.xml
+++ b/android/lib/src/main/AndroidManifest.xml
@@ -23,7 +23,7 @@
         </service>
         <provider
             android:name="com.marianhello.bgloc.sync.DummyContentProvider"
-            android:authorities="@string/content_authority"
+            android:authorities="${applicationId}.provider"
             android:exported="false"
             android:syncable="true"/>
         <service android:enabled="true" android:exported="false" android:name="com.marianhello.bgloc.LocationService" />


### PR DESCRIPTION
Using gradle and applicationId for the content provider has the following advantages:

* Backwards compatible. Accepting this PR is straightforward
* Allows users to build and install different flavours (debug, stage, release)
* We can even remove a line from res/values in the android documentation. I haven't done that because account type is still necessary.

Read more: https://stackoverflow.com/questions/16777534/using-build-types-in-gradle-to-run-same-app-that-uses-contentprovider-on-one-dev