### PR TITLE
Go to location settings not working on iOS 10 or above

### DIFF
--- a/ios/BackgroundGeolocation/BackgroundGeolocationFacade.m
+++ b/ios/BackgroundGeolocation/BackgroundGeolocationFacade.m
@@ -311,7 +311,11 @@ FMDBLogger *sqliteLogger;
 
 - (void) showLocationSettings
 {
-    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"prefs:root=LOCATION_SERVICES"]];
+    if (@available(iOS 10, *)) {
+        [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"App-Prefs:root=Privacy&path=LOCATION"]];
+    } else {
+        [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"prefs:root=LOCATION_SERVICES"]];
+    }
 }
 
 - (Location*) getStationaryLocation


### PR DESCRIPTION
showLocationSettings method now checks iOS version. If below 10, keep the same behaviour as today. Otherwise, use the updated settings string path.