### PR TITLE
Add prepublish script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "optimized background location tracking",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "prepublish": "node ./scripts/prepublish"
   },
   "repository": {
     "type": "git",

--- a/scripts/prepublish/index.js
+++ b/scripts/prepublish/index.js
@@ -1,0 +1,10 @@
+const OS = require('os')
+const { exec } = require('child_process')
+
+const platform = OS.platform()
+
+if (platform === 'darwin' || platform === 'linux') {
+  exec('./scripts/prepublish/script.sh')
+} else if (platform === 'win32') {
+  exec('scripts\\prepublish\\script.bat')
+}

--- a/scripts/prepublish/script.bat
+++ b/scripts/prepublish/script.bat
@@ -1,0 +1,7 @@
+git.exe submodule init
+git.exe submodule update
+git.exe submodule foreach git pull
+
+md android\lib\src\main\res\
+robocopy %CD%\android\common\src\main\java\ %CD%\android\lib\src\main\java\ /E
+robocopy %CD%\android\common\src\main\res\ %CD%\android\lib\src\main\res\ /E

--- a/scripts/prepublish/script.bat
+++ b/scripts/prepublish/script.bat
@@ -1,6 +1,5 @@
 git.exe submodule init
 git.exe submodule update
-git.exe submodule foreach git pull
 
 md android\lib\src\main\res\
 robocopy %CD%\android\common\src\main\java\ %CD%\android\lib\src\main\java\ /E

--- a/scripts/prepublish/script.bat
+++ b/scripts/prepublish/script.bat
@@ -1,6 +1,3 @@
-git.exe submodule init
-git.exe submodule update
-
 md android\lib\src\main\res\
-robocopy %CD%\android\common\src\main\java\ %CD%\android\lib\src\main\java\ /E
-robocopy %CD%\android\common\src\main\res\ %CD%\android\lib\src\main\res\ /E
+
+git.exe submodule init && git.exe submodule update && robocopy %CD%\android\common\src\main\java\ %CD%\android\lib\src\main\java\ /E && robocopy %CD%\android\common\src\main\res\ %CD%\android\lib\src\main\res\ /E

--- a/scripts/prepublish/script.sh
+++ b/scripts/prepublish/script.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-git submodule init
-git submodule update
-
 mkdir -p android/lib/src/main/res/
-cp -r android/common/src/main/java/* android/lib/src/main/java/
-cp -r android/common/src/main/res/* android/lib/src/main/res/
+
+git submodule init && git submodule update && cp -r android/common/src/main/java/* android/lib/src/main/java/ && cp -r android/common/src/main/res/* android/lib/src/main/res/

--- a/scripts/prepublish/script.sh
+++ b/scripts/prepublish/script.sh
@@ -2,7 +2,6 @@
 
 git submodule init
 git submodule update
-git submodule foreach git pull
 
 mkdir -p android/lib/src/main/res/
 cp -r android/common/src/main/java/* android/lib/src/main/java/

--- a/scripts/prepublish/script.sh
+++ b/scripts/prepublish/script.sh
@@ -2,6 +2,7 @@
 
 git submodule init
 git submodule update
+git submodule foreach git pull
 
 mkdir -p android/lib/src/main/res/
 cp -r android/common/src/main/java/* android/lib/src/main/java/


### PR DESCRIPTION
At the moment, before the publication of the package, the script does not work, since it was not added to the **package.json** file. As a consequence, there is no copying of files from the submodules and an error of missing files appears during the build of the application.
Another topic for discussion is adding a **prepublishOnly** script to the **package.json** file. The 
[documentation](https://docs.npmjs.com/misc/scripts) says it differs from the **prepublish** in that it works only before the publication of the npm package. **prepublish** script is triggered also **npm install** is launched. I guess that your goal is the first option, **prepublishOnly**. It's right?