### PR TITLE
Sent an event when the http request is unauthorized

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,10 @@ class BgTracking extends Component {
       // But you might be counting on it to receive location updates in the UI, so you could just reconfigure and set `url` to null.
     });
 
+    BackgroundGeolocation.on('http_authorization', () => {
+      console.log('[INFO] App needs to authorize the http requests');
+    });
+
     BackgroundGeolocation.checkStatus(status => {
       console.log('[INFO] BackgroundGeolocation service is running', status.isRunning);
       console.log('[INFO] BackgroundGeolocation services enabled', status.locationServicesEnabled);
@@ -567,6 +571,7 @@ Unregister all event listeners for given event
 | `foreground`        |                        | Android      | all         | app entered foreground state (visible)           |
 | `background`        |                        | Android      | all         | app entered background state                     |
 | `abort_requested`   |                        | all          | all         | server responded with "285 Updates Not Required" |
+| `http_authorization`|                        | all          | all         | server responded with "401 Unauthorized"         |
 
 ### Location event
 | Location parameter     | Type      | Description                                                            |

--- a/android/lib/src/main/java/com/marianhello/bgloc/react/BackgroundGeolocationModule.java
+++ b/android/lib/src/main/java/com/marianhello/bgloc/react/BackgroundGeolocationModule.java
@@ -40,6 +40,7 @@ public class BackgroundGeolocationModule extends ReactContextBaseJavaModule impl
     public static final String START_EVENT = "start";
     public static final String STOP_EVENT = "stop";
     public static final String ABORT_REQUESTED_EVENT = "abort_requested";
+    public static final String HTTP_AUTHORIZATION_EVENT = "http_authorization";
     public static final String ERROR_EVENT = "error";
 
     private static final int PERMISSIONS_REQUEST_CODE = 1;
@@ -411,5 +412,10 @@ public class BackgroundGeolocationModule extends ReactContextBaseJavaModule impl
     @Override
     public void onAbortRequested() {
         sendEvent(ABORT_REQUESTED_EVENT, null);
+    }
+
+    @Override
+    public void onHttpAuthorization() {
+        sendEvent(HTTP_AUTHORIZATION_EVENT, null);
     }
 }

--- a/index.js
+++ b/index.js
@@ -22,7 +22,8 @@ var BackgroundGeolocation = {
     'authorization',
     'foreground',
     'background',
-    'abort_requested'
+    'abort_requested',
+    'http_authorization'
   ],
 
   DISTANCE_FILTER_PROVIDER: 0,


### PR DESCRIPTION
Related issue:
https://github.com/mauron85/react-native-background-geolocation/issues/307

Related PR:
https://github.com/mauron85/background-geolocation-android/pull/19

Library clients will be able to listen for 401 Unauthorized status codes received from http server.

**I've implemented only the android part of the functionality. I'll need help for the iOS.**