### PR TITLE
ios: sent an event when the http request is unauthorized

### DIFF
--- a/ios/RCTBackgroundGeolocation/RCTBackgroundGeolocation.m
+++ b/ios/RCTBackgroundGeolocation/RCTBackgroundGeolocation.m
@@ -387,6 +387,16 @@ RCT_EXPORT_METHOD(forceSync:(RCTResponseSenderBlock)success failure:(RCTResponse
     }
 }
 
+- (void) onHttpAuthorization
+{
+    RCTLogInfo(@"RCTBackgroundGeoLocation http authorization");
+    
+    if (_bridge)
+    {
+        [self sendEvent:@"http_authorization"];
+    }
+}
+
 /**@
  * on UIApplicationDidFinishLaunchingNotification
  */


### PR DESCRIPTION
Related issue:
https://github.com/mauron85/react-native-background-geolocation/issues/307

Related PR:
https://github.com/mauron85/background-geolocation-ios/pull/5

Library clients will be able to listen for 401 Unauthorized status codes received from http server.