### PR TITLE
Change the react-native link command repositories.

### DIFF
--- a/scripts/postlink.js
+++ b/scripts/postlink.js
@@ -11,8 +11,8 @@ if (!isInstalled.forAndroid()) {
   // TODO: it would be nicer if react-native link has support for multi projects itself
   // Please vote:
   // https://react-native.canny.io/feature-requests/p/enable-subprojects-in-native-android-components-to-enable-code-reuse-with-cordov
-  const applyPatch = require('react-native/local-cli/link/android/patches/applyPatch');
-  const makeSettingsPatch = require('react-native/local-cli/link/android/patches/makeSettingsPatch');
+  const applyPatch = require('@react-native-community/cli/build/commands/link/android/patches/applyPatch').default;
+  const makeSettingsPatch = require('@react-native-community/cli/build/commands/link/android/patches/makeSettingsPatch').default;
   applyPatch(
     config.settingsGradlePath,
     makeSettingsPatch(

--- a/scripts/postunlink.js
+++ b/scripts/postunlink.js
@@ -3,8 +3,8 @@ const config = require('./config');
 const isInstalled = require('./isInstalled');
 
 if (isInstalled.forAndroid()) {
-  const revokePatch = require('react-native/local-cli/link/android/patches/revokePatch');
-  const makeSettingsPatch = require('react-native/local-cli/link/android/patches/makeSettingsPatch');
+  const revokePatch = require('@react-native-community/cli/build/commands/link/android/patches/revokePatch').default;
+  const makeSettingsPatch = require('@react-native-community/cli/build/commands/link/android/patches/makeSettingsPatch').default;
   revokePatch(
     config.settingsGradlePath,
     makeSettingsPatch(


### PR DESCRIPTION
In RN 0.59, the repositories of react-native link command moved to
react-native-community repository.[1]

The react-native-background-geolocation used the old repository,
so `react-native link` command failed.

This patch will change these repository.

[1] https://facebook.github.io/react-native/blog/#cli-improvements