### PR TITLE
minSdk version should not be declared on manifest

### DIFF
--- a/android/lib/src/main/AndroidManifest.xml
+++ b/android/lib/src/main/AndroidManifest.xml
@@ -52,7 +52,6 @@
         </receiver>
     </application>
 
-    <uses-sdk android:minSdkVersion="14" />
     <uses-permission android:name="android.hardware.location" />
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.WAKE_LOCK" />


### PR DESCRIPTION
minSdk version should only be declared in build.gradle file as it already is.
Declaring it at AndroidManifest.xml is breaking build on the newer versions of AndroidStudio/Gradle.