### PR TITLE
Fix all

### DIFF
--- a/@mauron85_react-native-background-geolocation.podspec
+++ b/@mauron85_react-native-background-geolocation.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.homepage     = package['homepage']
   s.platform     = :ios, "9.0"
 
-  s.source       = { :git => "https://github.com/mauron85/react-native-background-geolocation.git", :submodules => true }
+  s.source       = { :git => "https://github.com/hugosbg/react-native-background-geolocation.git", :submodules => true }
   s.source_files  = "ios/**/*.{h,m}"
   s.exclude_files = "ios/common/BackgroundGeolocationTests/*.{h,m}"
 

--- a/@mauron85_react-native-background-geolocation.podspec
+++ b/@mauron85_react-native-background-geolocation.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.homepage     = package['homepage']
   s.platform     = :ios, "9.0"
 
-  s.source       = { :git => "https://github.com/hugosbg/react-native-background-geolocation.git", :submodules => true }
+  s.source       = { :git => "https://github.com/mauron85/react-native-background-geolocation.git", :submodules => true }
   s.source_files  = "ios/**/*.{h,m}"
   s.exclude_files = "ios/common/BackgroundGeolocationTests/*.{h,m}"
 

--- a/@mauron85_react-native-background-geolocation.podspec
+++ b/@mauron85_react-native-background-geolocation.podspec
@@ -1,0 +1,20 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name         = "@mauron85_react-native-background-geolocation"
+  s.version      = package['version']
+  s.summary      = package['description']
+  s.license      = package['license']
+
+  s.authors      = package['author']
+  s.homepage     = package['homepage']
+  s.platform     = :ios, "9.0"
+
+  s.source       = { :git => "https://github.com/mauron85/react-native-background-geolocation.git", :submodules => true }
+  s.source_files  = "ios/**/*.{h,m}"
+  s.exclude_files = "ios/common/BackgroundGeolocationTests/*.{h,m}"
+
+  s.dependency 'React'
+end

--- a/ios/RCTBackgroundGeolocation.xcodeproj/project.pbxproj
+++ b/ios/RCTBackgroundGeolocation.xcodeproj/project.pbxproj
@@ -302,7 +302,6 @@
 					"$(inherited)",
 					"$(SRCROOT)/../../../React/**",
 					"$(SRCROOT)/../../react-native/React/**",
-					"$(SRCROOT)/react-native/React/**",
 					"$(SRCROOT)/../../../../ios/Pods/Headers/Public/**",
 				);
 				OTHER_LDFLAGS = "-ObjC";
@@ -318,7 +317,6 @@
 					"$(inherited)",
 					"$(SRCROOT)/../../../React/**",
 					"$(SRCROOT)/../../react-native/React/**",
-					"$(SRCROOT)/react-native/React/**",
 					"$(SRCROOT)/../../../../ios/Pods/Headers/Public/**",
 				);
 				OTHER_LDFLAGS = "-ObjC";

--- a/ios/RCTBackgroundGeolocation.xcodeproj/project.pbxproj
+++ b/ios/RCTBackgroundGeolocation.xcodeproj/project.pbxproj
@@ -303,7 +303,7 @@
 					"$(SRCROOT)/../../../React/**",
 					"$(SRCROOT)/../../react-native/React/**",
 					"$(SRCROOT)/react-native/React/**",
-					"$(SRCROOT)/../../../ios/Pods/Headers/Public/**",
+					"$(SRCROOT)/../../../../ios/Pods/Headers/Public/**",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -319,7 +319,7 @@
 					"$(SRCROOT)/../../../React/**",
 					"$(SRCROOT)/../../react-native/React/**",
 					"$(SRCROOT)/react-native/React/**",
-					"$(SRCROOT)/../../../ios/Pods/Headers/Public/**",
+					"$(SRCROOT)/../../../../ios/Pods/Headers/Public/**",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/package.json
+++ b/package.json
@@ -35,14 +35,5 @@
   },
   "devDependencies": {
     "plist": "^3.0.1"
-  },
-  "rnpm": {
-    "commands": {
-      "postlink": "node node_modules/@mauron85/react-native-background-geolocation/scripts/postlink.js",
-      "postunlink": "node node_modules/@mauron85/react-native-background-geolocation/scripts/postunlink.js"
-    },
-    "android": {
-      "sourceDir": "./android/lib"
-    }
   }
 }

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+    dependency: {
+        platforms: {
+            android: {
+                sourceDir: "./android/lib"
+            }
+        },
+        hooks: {
+            postlink: "./node node_modules/@mauron85/react-native-background-geolocation/scripts/postlink.js",
+            postunlink: "./node node_modules/@mauron85/react-native-background-geolocation/scripts/postunlink.js"
+        }
+    }
+};


### PR DESCRIPTION
fixes 

- RCTBridgeModule.h file not found
- No podspec file was found.
- rnpm deprecated

-------------------------------

# Testing..

1. #### Remove current module
```
react-native unlink @mauron85/react-native-background-geolocation
npm uninstall --save @mauron85/react-native-background-geolocation
```

2. #### Delete:
```
node_modules/
ios/Pods/
ios/build/
ios/Podfile.lock
ios/YOU_PROJECT.xcworkspace
```

3. #### Clear all cache:
```
npm cache clean --force
pod cache clean --all
watchman watch-del-all && rm -rf $TMPDIR/react-* && rm -rf $TMPDIR/metro*
```

4. #### Reinstall the dependencies:
`npm i`

5. #### Reinstall the module of my fork for testing:
`npm i --save https://github.com/hugosbg/react-native-background-geolocation.git`

6. #### Install Pods
`cd ios/ && pod install`

7. #### At the root of you project, created a `react-native.config.js`:
```
// disable autolink for ios
module.exports = {
    dependencies: {
        '@mauron85/react-native-background-geolocation': {
            platforms: {
                ios: null,
            },
        },
    },
};
```

8. #### Do manual Installation
https://github.com/mauron85/react-native-background-geolocation#ios-setup
