### PR TITLE
feat(androidx): migrated to androidx

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -16,3 +16,5 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+android.enableJetifier=true
+android.useAndroidX=true

--- a/android/lib/build.gradle
+++ b/android/lib/build.gradle
@@ -69,7 +69,7 @@ android {
     useLibrary 'android.test.mock'
 
     defaultConfig {
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         minSdkVersion project.ext.getMinSdkVersion()
         targetSdkVersion project.ext.getTargetSdkVersion()
         versionCode 1 // intentionally not updating version as we're not uploading to any java repository

--- a/android/lib/src/androidTest/java/com/marianhello/bgloc/react/ConfigMapperTest.java
+++ b/android/lib/src/androidTest/java/com/marianhello/bgloc/react/ConfigMapperTest.java
@@ -1,9 +1,9 @@
 package com.marianhello.bgloc.react;
 
 import android.content.Context;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.runner.AndroidJUnit4;
-import android.support.test.filters.SmallTest;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.SmallTest;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReadableMap;

--- a/android/lib/src/main/java/com/marianhello/bgloc/react/headless/HeadlessService.java
+++ b/android/lib/src/main/java/com/marianhello/bgloc/react/headless/HeadlessService.java
@@ -2,7 +2,7 @@ package com.marianhello.bgloc.react.headless;
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import com.facebook.react.HeadlessJsTaskService;
 import com.facebook.react.bridge.Arguments;


### PR DESCRIPTION
Theses changes made the library work on one of my project. And I think it might be easier for other people to contribute to this project in the future if it's natively using androidx.

Tests fail because no react-native dependencies is found so it's ok.