### PR TITLE
android sdk 31, android exported fix

### DIFF
--- a/android/lib/src/main/AndroidManifest.xml
+++ b/android/lib/src/main/AndroidManifest.xml
@@ -31,6 +31,7 @@
                 android:resource="@xml/syncadapter"/>
         </service>
         <service
+            android:exported="false"
             android:name="com.marianhello.bgloc.sync.AuthenticatorService">
             <intent-filter>
                 <action android:name="android.accounts.AccountAuthenticator"/>


### PR DESCRIPTION
Fixes the issue https://github.com/mauron85/react-native-background-geolocation/issues/571.
The android play store doesn't accept the app bundle otherwise